### PR TITLE
lane_planner: Both range_min and range_max should be index numbers.

### DIFF
--- a/lane_planner/nodes/lane_select/lane_select_core.cpp
+++ b/lane_planner/nodes/lane_select/lane_select_core.cpp
@@ -785,7 +785,7 @@ int32_t getClosestWaypointNumber(const autoware_msgs::Lane &current_lane, const 
   std::vector<uint32_t> idx_vec;
   // if previous number is -1, search closest waypoint from waypoints in front of current pose
   uint32_t range_min = 0;
-  uint32_t range_max = current_lane.waypoints.size();
+  uint32_t range_max = current_lane.waypoints.size() - 1;
   if (previous_number == -1)
   {
     idx_vec.reserve(current_lane.waypoints.size());
@@ -808,7 +808,7 @@ int32_t getClosestWaypointNumber(const autoware_msgs::Lane &current_lane, const 
   }
   const LaneDirection dir = getLaneDirection(current_lane);
   const int sgn = (dir == LaneDirection::Forward) ? 1 : (dir == LaneDirection::Backward) ? -1 : 0;
-  for (uint32_t i = range_min; i < range_max; i++)
+  for (uint32_t i = range_min; i <= range_max; i++)
   {
     geometry_msgs::Point converted_p =
       convertPointIntoRelativeCoordinate(current_lane.waypoints.at(i).pose.pose.position, current_pose);


### PR DESCRIPTION
Transferred from GitLab. See original PR for details:
https://gitlab.com/autowarefoundation/autoware.ai/core_planning/-/merge_requests/89