### PR TITLE
pure_pursuit: disable reset of is_waypoint_set flag after each control loop

### DIFF
--- a/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/pure_pursuit/src/pure_pursuit_core.cpp
@@ -140,7 +140,6 @@ void PurePursuitNode::run()
 
     is_pose_set_ = false;
     is_velocity_set_ = false;
-    is_waypoint_set_ = false;
 
     loop_rate.sleep();
   }


### PR DESCRIPTION
Transferred from GitLab. See original PR for details:
https://gitlab.com/autowarefoundation/autoware.ai/core_planning/-/merge_requests/90