### PR TITLE
Add maximum retry parameter to way_planner

### DIFF
--- a/way_planner/include/way_planner_core.h
+++ b/way_planner/include/way_planner_core.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Autoware Foundation. All rights reserved.
+ * Copyright 2016-2020 Autoware Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,6 +105,7 @@ public:
   bool       bEnableRvizInput;
   bool       bEnableReplanning;
   double       pathDensity;
+  int        planningMaxAttempt;
   MAP_SOURCE_TYPE  mapSource;
 
 
@@ -116,6 +117,7 @@ public:
     bEnableLaneChange   = false;
     bEnableRvizInput   = true;
     pathDensity      = 0.5;
+    planningMaxAttempt = 0;
     mapSource       = MAP_KML_FILE;
   }
 };

--- a/way_planner/launch/way_planner.launch
+++ b/way_planner/launch/way_planner.launch
@@ -9,6 +9,7 @@
   <arg name="velocitySource"          default="2" /> <!-- read velocities from (0- Odometry, 1- autoware current_velocities, 2- car_info) "" -->
   <arg name="mapSource"             default="1" /> <!-- Autoware=0, Vector Map Folder=1, kml file=2 -->
   <arg name="mapFileName"           default="/media/hatem/8ac0c5d5-8793-4b98-8728-55f8d67ec0f4/data/ToyotaCity2/map/vector_map/" /> <!-- incase of kml map source -->  
+  <arg name="planningMaxAttempt" default="0" /> <!-- When no valid path can be found, retry the process up to a maximum number of attempt, zero means unlimited, only positive values -->
   
 <node pkg="way_planner" type="way_planner" name="way_planner" output="screen">
     
@@ -21,6 +22,7 @@
     <param name="velocitySource"       value="$(arg velocitySource)" />
     <param name="mapSource"         value="$(arg mapSource)" />
     <param name="mapFileName"         value="$(arg mapFileName)" />
+    <param name="planningMaxAttempt" value="$(arg planningMaxAttempt)" />
           
   </node> 
   


### PR DESCRIPTION
## New feature implementation

### Implemented feature
Add a maximum retry parameter to the way_planner node

### Implementation description
Add a parameter to the node that enables it to retry the planning to a waypoint, when the maximum retry amount is reached, the current goal waypoint is removed.
