### PR TITLE
Enable way_planner to return path close to the goal

### DIFF
--- a/way_planner/include/way_planner_core.h
+++ b/way_planner/include/way_planner_core.h
@@ -105,6 +105,7 @@ public:
   bool       bEnableRvizInput;
   bool       bEnableReplanning;
   double       pathDensity;
+  double     fallbackMinGoalDistanceTh;
   int        planningMaxAttempt;
   MAP_SOURCE_TYPE  mapSource;
 
@@ -117,6 +118,7 @@ public:
     bEnableLaneChange   = false;
     bEnableRvizInput   = true;
     pathDensity      = 0.5;
+    fallbackMinGoalDistanceTh = 0.0;
     planningMaxAttempt = 0;
     mapSource       = MAP_KML_FILE;
   }

--- a/way_planner/launch/way_planner.launch
+++ b/way_planner/launch/way_planner.launch
@@ -9,6 +9,7 @@
   <arg name="velocitySource"          default="2" /> <!-- read velocities from (0- Odometry, 1- autoware current_velocities, 2- car_info) "" -->
   <arg name="mapSource"             default="1" /> <!-- Autoware=0, Vector Map Folder=1, kml file=2 -->
   <arg name="mapFileName"           default="/media/hatem/8ac0c5d5-8793-4b98-8728-55f8d67ec0f4/data/ToyotaCity2/map/vector_map/" /> <!-- incase of kml map source -->  
+  <arg name="fallbackMinGoalDistanceTh" default="0.0" /> <!-- When no valid path can be found, look for the closest valid path to the goal with distance under this threshold -->
   <arg name="planningMaxAttempt" default="0" /> <!-- When no valid path can be found, retry the process up to a maximum number of attempt, zero means unlimited, only positive values -->
   
 <node pkg="way_planner" type="way_planner" name="way_planner" output="screen">
@@ -22,6 +23,7 @@
     <param name="velocitySource"       value="$(arg velocitySource)" />
     <param name="mapSource"         value="$(arg mapSource)" />
     <param name="mapFileName"         value="$(arg mapFileName)" />
+    <param name="fallbackMinGoalDistanceTh" value="$(arg fallbackMinGoalDistanceTh)" />
     <param name="planningMaxAttempt" value="$(arg planningMaxAttempt)" />
           
   </node> 

--- a/way_planner/nodes/way_planner_core.cpp
+++ b/way_planner/nodes/way_planner_core.cpp
@@ -56,11 +56,17 @@ way_planner_core::way_planner_core()
   nh.getParam("/way_planner/enableRvizInput"     , m_params.bEnableRvizInput);
   nh.getParam("/way_planner/enableReplan"     , m_params.bEnableReplanning);
   nh.getParam("/way_planner/enableHMI"       , m_params.bEnableHMI);
+  nh.getParam("/way_planner/fallbackMinGoalDistanceTh" , m_params.fallbackMinGoalDistanceTh);
   nh.getParam("/way_planner/planningMaxAttempt", m_params.planningMaxAttempt);
 
   // The planning max attempt feature parameter cannot be below zero
   if (m_params.planningMaxAttempt < 0) {
     m_params.planningMaxAttempt = 0;
+  }
+
+  // The fallback min goal distance threshold feature parameter cannot be below zero
+  if (m_params.fallbackMinGoalDistanceTh < 0) {
+    m_params.fallbackMinGoalDistanceTh = 0;
   }
 
   int iSource = 0;
@@ -381,7 +387,8 @@ bool way_planner_core::GenerateGlobalPlan(PlannerHNS::WayPoint& startPoint, Plan
   std::vector<int> predefinedLanesIds;
   double ret = m_PlannerH.PlanUsingDP(startPoint, goalPoint,
       MAX_GLOBAL_PLAN_DISTANCE, m_params.bEnableLaneChange, predefinedLanesIds,
-      m_Map, generatedTotalPaths, &m_PlanningVisualizeTree);
+      m_Map, generatedTotalPaths, &m_PlanningVisualizeTree,
+      m_params.fallbackMinGoalDistanceTh);
 
   m_pCurrGoal = PlannerHNS::MappingHelpers::GetClosestWaypointFromMap(goalPoint, m_Map);
 
@@ -391,7 +398,8 @@ bool way_planner_core::GenerateGlobalPlan(PlannerHNS::WayPoint& startPoint, Plan
   double ret = m_PlannerH.PlanUsingDP(startPoint, goalPoint,
           MAX_GLOBAL_PLAN_DISTANCE, m_params.bEnableLaneChange,
           predefinedLanesIds,
-          m_Map, generatedTotalPaths);
+          m_Map, generatedTotalPaths, nullptr,
+          m_params.fallbackMinGoalDistanceTh);
 #endif
 
 if(m_params.bEnableHMI)


### PR DESCRIPTION
## New feature implementation

### Implemented feature
Enable way_planner to return a valid path close enough to the goal if any other path to the goal is not found.

### Implementation description
Add a parameter to enable way_planner to return a valid path close to the goal if there is no path found to it.
The parameter value indicates how close to the goal the solution should be.