### PR TITLE
Fix an inaccurate warning msg inside VelocitySetPath::calcInterval

### DIFF
--- a/waypoint_planner/src/velocity_set/velocity_set_path.cpp
+++ b/waypoint_planner/src/velocity_set/velocity_set_path.cpp
@@ -192,7 +192,7 @@ void VelocitySetPath::initializeNewWaypoints()
 double VelocitySetPath::calcInterval(const int begin, const int end) const
 {
   // check index
-  if (begin < 0 || begin >= getPrevWaypointsSize() || end < 0 || end >= getPrevWaypointsSize() || begin >= end)
+  if (begin < 0 || begin >= getPrevWaypointsSize() || end < 0 || end >= getPrevWaypointsSize() || begin > end)
   {
     ROS_WARN_THROTTLE(1, "Invalid input index range");
     return 0.0;


### PR DESCRIPTION
A ros warning msg ""Invalid input index range"" is always on. It is defined inside function VelocitySetPath::calcInterval(const int begin, const int end). The problem is caused by the last condition check "begin >= end". With a closer look of the code, it is a valid case when begin == end" in which case the returned value should be 0.0. To fix it properly, we should return std::nan(const char* arg) when input index is not valid and all the callers need to check the returned function. For now, we just remove the condition check.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_planning/-/merge_requests/30