### PR TITLE
Fix limitAccelDecel issue when the velocity profile contains multiple up and downs.

### DIFF
--- a/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner.cpp
+++ b/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner.cpp
@@ -406,11 +406,10 @@ void WaypointReplanner::limitAccelDecel(const unsigned long idx, autoware_msgs::
       const geometry_msgs::Point& p0 = lane.waypoints[next - sgn[j]].pose.pose.position;
       const geometry_msgs::Point& p1 = lane.waypoints[next].pose.pose.position;
       const double dist = std::hypot(p0.x - p1.x, p0.y - p1.y);
+      // maximum speed based on max_accel_limit or max_decel_limit
       v = sqrt(2 * acc[j] * dist + v * v);
-      if (v > config_.velocity_max || v > lane.waypoints[next].twist.twist.linear.x)
-      {
-        break;
-      }
+      // cap it in case it is larger than the current velocity or velocity_max.
+      v = std::fmin(v, std::fmin(lane.waypoints[next].twist.twist.linear.x, config_.velocity_max));
       lane.waypoints[next].twist.twist.linear.x = v;
     }
   }

--- a/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner.cpp
+++ b/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner.cpp
@@ -409,7 +409,7 @@ void WaypointReplanner::limitAccelDecel(const unsigned long idx, autoware_msgs::
       // maximum speed based on max_accel_limit or max_decel_limit
       v = sqrt(2 * acc[j] * dist + v * v);
       // cap it in case it is larger than the current velocity or velocity_max.
-      v = std::fmin(v, std::fmin(lane.waypoints[next].twist.twist.linear.x, config_.velocity_max));
+      v = std::min({v, lane.waypoints[next].twist.twist.linear.x, config_.velocity_max});
       lane.waypoints[next].twist.twist.linear.x = v;
     }
   }


### PR DESCRIPTION
- The purpose of Function limitAccelDecel() is to limit the speed at each waypoint based on max_accel and max_decel. The break statement in the inside loop stops the limiting process right after hitting the velocity_max the first time. It does not work as expected if the velocity profile of waypoints contains a few up and downs.
- To verify the issue, record a route with a few speed up/down sequences first (figure 8 shape is good choice). Before start the node, make sure set the velocity_max a bit higher than the highest recorded velocity and enable replan_curve_mode.
- Verified with a recorded figure 8 route at velocity_max of 20, 30, and 40 kmh. Also verified with max_accel of 0.2, 0.3, and 0.4 m/s^2.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_planning/-/merge_requests/50