### PR TITLE
waypoint_replanner configuration parameter cleanup

### DIFF
--- a/waypoint_maker/launch/waypoint_loader.launch
+++ b/waypoint_maker/launch/waypoint_loader.launch
@@ -7,17 +7,13 @@
   <arg name="resample_mode" default="True" />
   <arg name="resample_interval" default="1.0" />
   <arg name="replan_curve_mode" default="False" />
-  <arg name="overwrite_vmax_mode" default="False" />
   <arg name="replan_endpoint_mode" default="True" />
   <arg name="velocity_max" default="20" />
-  <arg name="radius_thresh" default="20" />
   <arg name="radius_min" default="6" />
   <arg name="velocity_min" default="4" />
   <arg name="accel_limit" default="0.5" />
   <arg name="decel_limit" default="0.3" />
-  <arg name="velocity_offset" default="4" />
-  <arg name="braking_distance" default="5" />
-  <arg name="end_point_offset" default="1" />
+  <arg name="lateral_accel_limit" default="2.0" />
   <arg name="use_decision_maker" default="false" />
 
   <!-- rosrun waypoint_maker waypoint_loader _multi_lane_csv:="path file" -->
@@ -30,17 +26,13 @@
     <param name="resample_mode" value="$(arg resample_mode)" />
     <param name="resample_interval" value="$(arg resample_interval)" />
     <param name="replan_curve_mode" value="$(arg replan_curve_mode)" />
-    <param name="overwrite_vmax_mode" value="$(arg overwrite_vmax_mode)" />
     <param name="replan_endpoint_mode" value="$(arg replan_endpoint_mode)" />
     <param name="velocity_max" value="$(arg velocity_max)" />
-    <param name="radius_thresh" value="$(arg radius_thresh)" />
     <param name="radius_min" value="$(arg radius_min)" />
     <param name="velocity_min" value="$(arg velocity_min)" />
     <param name="accel_limit" value="$(arg accel_limit)" />
     <param name="decel_limit" value="$(arg decel_limit)" />
-    <param name="velocity_offset" value="$(arg velocity_offset)" />
-    <param name="braking_distance" value="$(arg braking_distance)" />
-    <param name="end_point_offset" value="$(arg end_point_offset)" />
+    <param name="lateral_accel_limit" value="$(arg lateral_accel_limit)" />
     <param name="use_decision_maker" value="$(arg use_decision_maker)" />
   </node>
   <node pkg="waypoint_maker" type="waypoint_marker_publisher" name="waypoint_marker_publisher" />

--- a/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner.cpp
+++ b/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner.cpp
@@ -29,8 +29,6 @@ WaypointReplanner::~WaypointReplanner()
 void WaypointReplanner::updateConfig(const WaypointReplannerConfig& config)
 {
   config_ = config;
-  config_.radius_inf = 10 * config_.radius_thresh;
-  config_.velocity_param = calcVelParam(config_.velocity_max);
 }
 
 void WaypointReplanner::initParameter(const autoware_config_msgs::ConfigWaypointReplanner::ConstPtr& conf)
@@ -41,17 +39,13 @@ void WaypointReplanner::initParameter(const autoware_config_msgs::ConfigWaypoint
   temp_config.velocity_min = kmph2mps(conf->velocity_min);
   temp_config.accel_limit = conf->accel_limit;
   temp_config.decel_limit = conf->decel_limit;
-  temp_config.radius_thresh = conf->radius_thresh;
+  temp_config.lateral_accel_limit = conf->lateral_accel_limit;
   temp_config.radius_min = conf->radius_min;
   temp_config.lookup_crv_width = 5;
   temp_config.resample_mode = conf->resample_mode;
   temp_config.resample_interval = conf->resample_interval;
   temp_config.replan_curve_mode = conf->replan_curve_mode;
   temp_config.replan_endpoint_mode = conf->replan_endpoint_mode;
-  temp_config.overwrite_vmax_mode = conf->overwrite_vmax_mode;
-  temp_config.velocity_offset = conf->velocity_offset;
-  temp_config.end_point_offset = conf->end_point_offset;
-  temp_config.braking_distance = conf->braking_distance;
 
   updateConfig(temp_config);
 }
@@ -74,41 +68,38 @@ void WaypointReplanner::replanLaneWaypointVel(autoware_msgs::Lane& lane)
   const LaneDirection dir = getLaneDirection(lane);
   unsigned long last = lane.waypoints.size() - 1;
   changeVelSign(lane, true);
-  limitVelocityByRange(0, last, 0, config_.velocity_max, lane);
+  limitVelocityByRange(0, last, config_.velocity_max, lane);
   if (config_.resample_mode)
   {
     resampleLaneWaypoint(config_.resample_interval, lane, dir);
     last = lane.waypoints.size() - 1;
   }
+
+  // set velocity based on curvature at each waypoint
   if (config_.replan_curve_mode)
   {
     std::vector<double> curve_radius;
-    KeyVal curve_list;
     createRadiusList(lane, curve_radius);
-    createCurveList(curve_radius, curve_list);
-    if (config_.overwrite_vmax_mode)
-    {// set velocity_max for all_point
-      setVelocityByRange(0, last, 0, config_.velocity_max, lane);
-    }
-    // set velocity by curve
-    for (const auto& el : curve_list)
+    setVelocityByRange(0, last, config_.velocity_max, lane);
+    for (unsigned long i = 0; i < curve_radius.size(); i++)
     {
-      const double& radius = el.second.second;
-      double vmin = config_.velocity_max - config_.velocity_param * (config_.radius_thresh - radius);
-      vmin = (vmin < config_.velocity_min) ? config_.velocity_min : vmin;
-      limitVelocityByRange(el.first, el.second.first, config_.velocity_offset, vmin, lane);
+      lane.waypoints[i].twist.twist.linear.x = std::fmin(lane.waypoints[i].twist.twist.linear.x, 
+                                                        std::sqrt(config_.lateral_accel_limit * std::fmax(curve_radius[i], config_.radius_min)));
     }
+    limitVelocityByRange(0, last, config_.velocity_max, lane);
   }
-  // set velocity on start & end of lane
+
+  // set velocity at end of the lane
   if (config_.replan_endpoint_mode)
   {
-    const unsigned long zerospeed_start = last - config_.end_point_offset;
-    const unsigned long lowspeed_start = zerospeed_start - config_.braking_distance;
-    raiseVelocityByRange(0, last, 0, config_.velocity_min, lane);
-    limitVelocityByRange(0, 0, 0, config_.velocity_min, lane);
-    limitVelocityByRange(lowspeed_start, last, 0, config_.velocity_min, lane);
-    setVelocityByRange(zerospeed_start, last, 0, 0.0, lane);
+    // set last waypoint speed to zero
+    setVelocityByRange(last - 1, last, 0.0, lane);
+    // set minimum speed for each waypoint except for the last waypoint. 
+    raiseVelocityByRange(0, last - 1, config_.velocity_min, lane);
+    // smooth it out again
+    limitVelocityByRange(0, 0, config_.velocity_min, lane);
   }
+
   if (dir == LaneDirection::Backward)
   {
     changeVelSign(lane, false);
@@ -257,12 +248,14 @@ const CbufGPoint WaypointReplanner::getCrvPoints(const autoware_msgs::Lane& lane
 
 void WaypointReplanner::createRadiusList(const autoware_msgs::Lane& lane, std::vector<double>& curve_radius)
 {
+  static constexpr double radius_inf = 5.0e2;
+
   if (lane.waypoints.empty())
   {
     return;
   }
   curve_radius.resize(lane.waypoints.size());
-  curve_radius.at(0) = curve_radius.back() = config_.radius_inf;
+  curve_radius.at(0) = curve_radius.back() = radius_inf;
 
   for (unsigned long i = 1; i < lane.waypoints.size() - 1; i++)
   {
@@ -272,70 +265,22 @@ void WaypointReplanner::createRadiusList(const autoware_msgs::Lane& lane, std::v
     // if going straight
     if (curve_param.empty())
     {
-      curve_radius.at(i) = config_.radius_inf;
+      curve_radius.at(i) = radius_inf;
     }
     // else if turnning curve
     else
     {
-      curve_radius.at(i) = (curve_param[2] > config_.radius_inf) ? config_.radius_inf : curve_param[2];
+      curve_radius.at(i) = (curve_param[2] > radius_inf) ? radius_inf : curve_param[2];
     }
   }
 }
 
-const double WaypointReplanner::calcVelParam(double vmax) const
-{
-  if (fabs(config_.radius_thresh - config_.radius_min) < 1e-8)
-  {
-    return DBL_MAX;  // error
-  }
-  return (vmax - config_.velocity_min) / (config_.radius_thresh - config_.radius_min);
-}
-
-void WaypointReplanner::createCurveList(const std::vector<double>& curve_radius, KeyVal& curve_list)
-{
-  unsigned long index = 0;
-  bool on_curve = false;
-  double radius_localmin = DBL_MAX;
-  for (unsigned long i = 1; i < curve_radius.size(); i++)
-  {
-    if (!on_curve && curve_radius[i] <= config_.radius_thresh && curve_radius[i - 1] > config_.radius_thresh)
-    {
-      index = i;
-      on_curve = true;
-    }
-    else if (on_curve && curve_radius[i - 1] <= config_.radius_thresh && curve_radius[i] > config_.radius_thresh)
-    {
-      on_curve = false;
-      if (radius_localmin < config_.radius_min)
-      {
-        radius_localmin = config_.radius_min;
-      }
-      curve_list[index] = std::make_pair(i, radius_localmin);
-      radius_localmin = DBL_MAX;
-    }
-    if (!on_curve)
-    {
-      continue;
-    }
-    if (radius_localmin > curve_radius[i])
-    {
-      radius_localmin = curve_radius[i];
-    }
-  }
-}
-
-
-void WaypointReplanner::setVelocityByRange(unsigned long start_idx, unsigned long end_idx, unsigned int offset,
+void WaypointReplanner::setVelocityByRange(unsigned long start_idx, unsigned long end_idx,
                                              double vel, autoware_msgs::Lane& lane)
 {
   if (lane.waypoints.empty())
   {
     return;
-  }
-  if (offset > 0)
-  {
-    start_idx = (start_idx > offset) ? (start_idx - offset) : 0;
-    end_idx = (end_idx > offset) ? (end_idx - offset) : 0;
   }
   end_idx = (end_idx >= lane.waypoints.size()) ? lane.waypoints.size() - 1 : end_idx;
   for (unsigned long idx = start_idx; idx <= end_idx; idx++)
@@ -344,17 +289,12 @@ void WaypointReplanner::setVelocityByRange(unsigned long start_idx, unsigned lon
   }
 }
 
-void WaypointReplanner::raiseVelocityByRange(unsigned long start_idx, unsigned long end_idx, unsigned int offset,
+void WaypointReplanner::raiseVelocityByRange(unsigned long start_idx, unsigned long end_idx,
                                            double vmin, autoware_msgs::Lane& lane)
 {
   if (lane.waypoints.empty())
   {
     return;
-  }
-  if (offset > 0)
-  {
-    start_idx = (start_idx > offset) ? (start_idx - offset) : 0;
-    end_idx = (end_idx > offset) ? (end_idx - offset) : 0;
   }
   end_idx = (end_idx >= lane.waypoints.size()) ? lane.waypoints.size() - 1 : end_idx;
   for (unsigned long idx = start_idx; idx <= end_idx; idx++)
@@ -367,17 +307,12 @@ void WaypointReplanner::raiseVelocityByRange(unsigned long start_idx, unsigned l
   }
 }
 
-void WaypointReplanner::limitVelocityByRange(unsigned long start_idx, unsigned long end_idx, unsigned int offset,
+void WaypointReplanner::limitVelocityByRange(unsigned long start_idx, unsigned long end_idx,
                                              double vmin, autoware_msgs::Lane& lane)
 {
   if (lane.waypoints.empty())
   {
     return;
-  }
-  if (offset > 0)
-  {
-    start_idx = (start_idx > offset) ? (start_idx - offset) : 0;
-    end_idx = (end_idx > offset) ? (end_idx - offset) : 0;
   }
   end_idx = (end_idx >= lane.waypoints.size()) ? lane.waypoints.size() - 1 : end_idx;
   for (unsigned long idx = start_idx; idx <= end_idx; idx++)

--- a/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner.h
+++ b/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner.h
@@ -35,20 +35,15 @@ struct WaypointReplannerConfig
 {
   double velocity_max = 0.0;
   double velocity_min = 0.0;
-  double velocity_param = 0.0;
   double accel_limit = 0.0;
   double decel_limit = 0.0;
-  double radius_thresh = 0.0;
+  double lateral_accel_limit = 0.0;
   double radius_min = 0.0;
-  double radius_inf = 0.0;
   bool resample_mode = false;
   double resample_interval = 0.0;
   bool replan_curve_mode = false;
   bool replan_endpoint_mode = false;
-  bool overwrite_vmax_mode = false;
-  double velocity_offset = 0.0;
-  double end_point_offset =  0.0;
-  double braking_distance = 0.0;
+  // The number of consective waypoints used to compute the local radius.
   int lookup_crv_width = 5;
 };
 
@@ -64,7 +59,7 @@ public:
   void initParameter(const autoware_config_msgs::ConfigWaypointReplanner::ConstPtr& conf);
   void replanLaneWaypointVel(autoware_msgs::Lane& lane);
 
-protected:
+private:
   void changeVelSign(autoware_msgs::Lane& lane, bool positive) const;
   void resampleLaneWaypoint(const double resample_interval, autoware_msgs::Lane& lane, LaneDirection dir);
   void resampleOnStraight(const CbufGPoint& curve_point, autoware_msgs::Lane& lane, LaneDirection dir);
@@ -76,19 +71,10 @@ protected:
   const CbufGPoint getCrvPoints(const autoware_msgs::Lane& lane, unsigned long index) const;
 
   void createRadiusList(const autoware_msgs::Lane& lane, std::vector<double>& curve_radius);
-  const double calcVelParam(double vmax) const;
-  void createCurveList(const std::vector<double>& curve_radius, KeyVal& curve_list);
-  void createVmaxList(const autoware_msgs::Lane& lane, const KeyVal &curve_list,
-    unsigned long offset, KeyVal &vmax_list);
-  double searchVmaxByRange(unsigned long start_idx, unsigned long end_idx, unsigned int offset,
-    const autoware_msgs::Lane &lane) const;
-  void setVelocityByRange(unsigned long start_idx, unsigned long end_idx, unsigned int offset, double vel,
-    autoware_msgs::Lane& lane);
-  void raiseVelocityByRange(unsigned long start_idx, unsigned long end_idx, unsigned int offset,
-    double vmin, autoware_msgs::Lane& lane);
+  void setVelocityByRange(unsigned long start_idx, unsigned long end_idx, double vel, autoware_msgs::Lane& lane);
+  void raiseVelocityByRange(unsigned long start_idx, unsigned long end_idx, double vmin, autoware_msgs::Lane& lane);
 
-  void limitVelocityByRange(unsigned long start_idx, unsigned long end_idx, unsigned int offset, double vmin,
-    autoware_msgs::Lane& lane);
+  void limitVelocityByRange(unsigned long start_idx, unsigned long end_idx, double vmin, autoware_msgs::Lane& lane);
   void limitAccelDecel(const unsigned long idx, autoware_msgs::Lane& lane);
 
   const std::vector<double> calcCurveParam(CbufGPoint point) const;

--- a/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner_node.cpp
+++ b/waypoint_maker/nodes/waypoint_replanner/waypoint_replanner_node.cpp
@@ -52,16 +52,12 @@ WaypointReplannerNode::WaypointReplannerNode() : pnh_("~"), is_first_publish_(tr
   pnh_.param<double>("velocity_min", velocity_min_kph, 0.0);
   pnh_.param<double>("accel_limit", temp_config.accel_limit, 0.0);
   pnh_.param<double>("decel_limit", temp_config.decel_limit, 0.0);
-  pnh_.param<double>("radius_thresh", temp_config.radius_thresh, 0.0);
+  pnh_.param<double>("lateral_accel_limit", temp_config.lateral_accel_limit, 0.0);
   pnh_.param<double>("radius_min", temp_config.radius_min, 0.0);
   pnh_.param<bool>("resample_mode", temp_config.resample_mode, false);
   pnh_.param<double>("resample_interval", temp_config.resample_interval, 0.0);
   pnh_.param<bool>("replan_curve_mode", temp_config.replan_curve_mode, false);
   pnh_.param<bool>("replan_endpoint_mode", temp_config.replan_endpoint_mode, false);
-  pnh_.param<bool>("overwrite_vmax_mode", temp_config.overwrite_vmax_mode, false);
-  pnh_.param<double>("velocity_offset", temp_config.velocity_offset, 0.0);
-  pnh_.param<double>("end_point_offset", temp_config.end_point_offset, 0.0);
-  pnh_.param<double>("braking_distance", temp_config.braking_distance, 0.0);
   pnh_.param<bool>("use_decision_maker", use_decision_maker_, false);
 
   temp_config.velocity_max = kmph2mps(velocity_max_kph);


### PR DESCRIPTION
Must be merged with https://github.com/Autoware-AI/messages/pull/6

1. Removed the following configuration parameters for waypoint_replanner:
```
float32 radius_thresh
int32 velocity_offset
int32 end_point_offset
int32 braking_distance
bool overwrite_vmax_mode
```
And one new configuration parameter

```
float32 lateral_accel_limit
```
2. If replan_curve_mode is true, limit the speed at each waypoint by the lateral_accel_limit and its curvature.
3. Remove some unused or undefined functions.

Verified in the vehicle at different max velocities (20 Kmh, 30 Kmh, and 40 Kmh).

Will be followed up by a PR in messages and utilities repo.

See original PR for more details: https://gitlab.com/astuff/autoware.ai/core_planning/-/merge_requests/51