### PR TITLE
Remove velocity_set's dependence on localizer_pose topic

### DIFF
--- a/waypoint_planner/include/waypoint_planner/velocity_set/velocity_set_info.h
+++ b/waypoint_planner/include/waypoint_planner/velocity_set/velocity_set_info.h
@@ -64,7 +64,7 @@ class VelocitySetInfo
   void pointsCallback(const sensor_msgs::PointCloud2ConstPtr &msg);
   void controlPoseCallback(const geometry_msgs::PoseStampedConstPtr &msg);
   void detectionCallback(const std_msgs::Int32 &msg);
-  void setLocalizerPose(geometry_msgs::TransformStamped *transformStamped);
+  void setLocalizerPose(const geometry_msgs::TransformStamped &map_to_lidar_tf);
 
   void clearPoints();
 

--- a/waypoint_planner/include/waypoint_planner/velocity_set/velocity_set_info.h
+++ b/waypoint_planner/include/waypoint_planner/velocity_set/velocity_set_info.h
@@ -21,6 +21,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <std_msgs/Int32.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <autoware_config_msgs/ConfigVelocitySet.h>
 
@@ -48,7 +49,7 @@ class VelocitySetInfo
   double remove_points_upto_;
 
   pcl::PointCloud<pcl::PointXYZ> points_;
-  geometry_msgs::PoseStamped localizer_pose_;  // pose of sensor
+  geometry_msgs::Pose localizer_pose_;  // pose of sensor
   geometry_msgs::PoseStamped control_pose_;    // pose of base_link
   bool set_pose_;
 
@@ -62,8 +63,8 @@ class VelocitySetInfo
   void configCallback(const autoware_config_msgs::ConfigVelocitySetConstPtr &msg);
   void pointsCallback(const sensor_msgs::PointCloud2ConstPtr &msg);
   void controlPoseCallback(const geometry_msgs::PoseStampedConstPtr &msg);
-  void localizerPoseCallback(const geometry_msgs::PoseStampedConstPtr &msg);
   void detectionCallback(const std_msgs::Int32 &msg);
+  void setLocalizerPose(geometry_msgs::TransformStamped *transformStamped);
 
   void clearPoints();
 
@@ -138,7 +139,7 @@ class VelocitySetInfo
     return control_pose_;
   }
 
-  geometry_msgs::PoseStamped getLocalizerPose() const
+  const geometry_msgs::Pose& getLocalizerPose() const
   {
     return localizer_pose_;
   }

--- a/waypoint_planner/src/velocity_set/velocity_set.cpp
+++ b/waypoint_planner/src/velocity_set/velocity_set.cpp
@@ -576,16 +576,15 @@ int main(int argc, char** argv)
   {
     ros::spinOnce();
 
-    geometry_msgs::TransformStamped map_to_lidar_tf;
-
     try
     {
-        map_to_lidar_tf = tfBuffer.lookupTransform("map", "lidar", ros::Time::now(), ros::Duration(2.0));
-        vs_info.setLocalizerPose(&map_to_lidar_tf);
+      geometry_msgs::TransformStamped map_to_lidar_tf = tfBuffer.lookupTransform(
+        "map", "velodyne", ros::Time::now(), ros::Duration(2.0));
+      vs_info.setLocalizerPose(map_to_lidar_tf);
     }
     catch(tf2::TransformException &ex)
     {
-        ROS_WARN("%s", ex.what());
+        ROS_WARN("Failed to get map->lidar transform. skip computation: %s", ex.what());
         continue;
     }
 

--- a/waypoint_planner/src/velocity_set/velocity_set_info.cpp
+++ b/waypoint_planner/src/velocity_set/velocity_set_info.cpp
@@ -110,9 +110,17 @@ void VelocitySetInfo::controlPoseCallback(const geometry_msgs::PoseStampedConstP
     set_pose_ = true;
 }
 
-void VelocitySetInfo::localizerPoseCallback(const geometry_msgs::PoseStampedConstPtr &msg)
+void VelocitySetInfo::setLocalizerPose(geometry_msgs::TransformStamped *map_to_lidar_tf)
 {
-  health_checker_ptr_->NODE_ACTIVATE();
-  health_checker_ptr_->CHECK_RATE("topic_rate_localizer_pose_slow", 8, 5, 1, "topic localizer_pose subscribe rate slow.");
-  localizer_pose_ = *msg;
+    geometry_msgs::Pose lidarPose;
+    geometry_msgs::Point lidarPoint;
+
+    lidarPoint.x = map_to_lidar_tf->transform.translation.x;
+    lidarPoint.y = map_to_lidar_tf->transform.translation.y;
+    lidarPoint.z = map_to_lidar_tf->transform.translation.z;
+
+    lidarPose.position = lidarPoint;
+    lidarPose.orientation = map_to_lidar_tf->transform.rotation;
+
+    localizer_pose_ = lidarPose;
 }

--- a/waypoint_planner/src/velocity_set/velocity_set_info.cpp
+++ b/waypoint_planner/src/velocity_set/velocity_set_info.cpp
@@ -110,17 +110,10 @@ void VelocitySetInfo::controlPoseCallback(const geometry_msgs::PoseStampedConstP
     set_pose_ = true;
 }
 
-void VelocitySetInfo::setLocalizerPose(geometry_msgs::TransformStamped *map_to_lidar_tf)
+void VelocitySetInfo::setLocalizerPose(const geometry_msgs::TransformStamped &map_to_lidar_tf)
 {
-    geometry_msgs::Pose lidarPose;
-    geometry_msgs::Point lidarPoint;
-
-    lidarPoint.x = map_to_lidar_tf->transform.translation.x;
-    lidarPoint.y = map_to_lidar_tf->transform.translation.y;
-    lidarPoint.z = map_to_lidar_tf->transform.translation.z;
-
-    lidarPose.position = lidarPoint;
-    lidarPose.orientation = map_to_lidar_tf->transform.rotation;
-
-    localizer_pose_ = lidarPose;
+    localizer_pose_.position.x = map_to_lidar_tf.transform.translation.x;
+    localizer_pose_.position.y = map_to_lidar_tf.transform.translation.y;
+    localizer_pose_.position.z = map_to_lidar_tf.transform.translation.z;
+    localizer_pose_.orientation = map_to_lidar_tf.transform.rotation;
 }

--- a/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
+++ b/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
@@ -171,7 +171,7 @@ int findClosestCrosswalk(const lanelet::ConstLanelets& crosswalks, const int clo
 // return EControl::Keep otherwise
 EControl crossWalkDetection(const pcl::PointCloud<pcl::PointXYZ>& points,
                             const lanelet::ConstLanelets& closest_crosswalks,
-                            const geometry_msgs::PoseStamped& localizer_pose, const int points_threshold,
+                            const geometry_msgs::Pose localizer_pose, const int points_threshold,
                             ObstaclePoints* obstacle_points)
 {
   for (auto lli = closest_crosswalks.begin(); lli != closest_crosswalks.end(); lli++)
@@ -184,7 +184,7 @@ EControl crossWalkDetection(const pcl::PointCloud<pcl::PointXYZ>& points,
     {
       geometry_msgs::Point point_geom, transformed_point_geom;
       lanelet::utils::conversion::toGeomMsgPt(point, &point_geom);
-      transformed_point_geom = calcRelativeCoordinate(point_geom, localizer_pose.pose);
+      transformed_point_geom = calcRelativeCoordinate(point_geom, localizer_pose);
       lanelet::BasicPoint2d transformed_point2d(transformed_point_geom.x, transformed_point_geom.y);
       transformed_poly2d.push_back(transformed_point2d);
     }
@@ -202,7 +202,7 @@ EControl crossWalkDetection(const pcl::PointCloud<pcl::PointXYZ>& points,
         point_temp.x = p.x;
         point_temp.y = p.y;
         point_temp.z = p.z;
-        obstacle_points->setStopPoint(calcAbsoluteCoordinate(point_temp, localizer_pose.pose));
+        obstacle_points->setStopPoint(calcAbsoluteCoordinate(point_temp, localizer_pose));
       }
       if (stop_count > points_threshold)
       {
@@ -219,7 +219,7 @@ EControl crossWalkDetection(const pcl::PointCloud<pcl::PointXYZ>& points,
 // same as velocity_set.cpp - except for no reference to vector maps or crosswalk
 int detectStopObstacle(const pcl::PointCloud<pcl::PointXYZ>& points, const int closest_waypoint, int detection_waypoint,
                        const autoware_msgs::Lane& lane, const lanelet::ConstLanelets& closest_crosswalks,
-                       double stop_range, double points_threshold, const geometry_msgs::PoseStamped& localizer_pose,
+                       double stop_range, double points_threshold, const geometry_msgs::Pose localizer_pose,
                        ObstaclePoints* obstacle_points, EObstacleType* obstacle_type,
                        const int wpidx_detection_result_by_other_nodes)
 {
@@ -255,7 +255,7 @@ int detectStopObstacle(const pcl::PointCloud<pcl::PointXYZ>& points, const int c
     }
 
     // waypoint seen by localizer
-    geometry_msgs::Point waypoint = calcRelativeCoordinate(lane.waypoints[i].pose.pose.position, localizer_pose.pose);
+    geometry_msgs::Point waypoint = calcRelativeCoordinate(lane.waypoints[i].pose.pose.position, localizer_pose);
     tf::Vector3 tf_waypoint = point2vector(waypoint);
     tf_waypoint.setZ(0);
 
@@ -273,7 +273,7 @@ int detectStopObstacle(const pcl::PointCloud<pcl::PointXYZ>& points, const int c
         point_temp.x = p.x;
         point_temp.y = p.y;
         point_temp.z = p.z;
-        obstacle_points->setStopPoint(calcAbsoluteCoordinate(point_temp, localizer_pose.pose));
+        obstacle_points->setStopPoint(calcAbsoluteCoordinate(point_temp, localizer_pose));
       }
     }
 
@@ -296,7 +296,7 @@ int detectStopObstacle(const pcl::PointCloud<pcl::PointXYZ>& points, const int c
 //  same as velocity_set.cpp - expect for no reference to vector maps
 int detectDecelerateObstacle(const pcl::PointCloud<pcl::PointXYZ>& points, const int closest_waypoint,
                              const autoware_msgs::Lane& lane, const double stop_range, const double deceleration_range,
-                             const double points_threshold, const geometry_msgs::PoseStamped& localizer_pose,
+                             const double points_threshold, const geometry_msgs::Pose localizer_pose,
                              ObstaclePoints* obstacle_points)
 {
   int decelerate_obstacle_waypoint = -1;
@@ -308,7 +308,7 @@ int detectDecelerateObstacle(const pcl::PointCloud<pcl::PointXYZ>& points, const
       break;
 
     // waypoint seen by localizer
-    geometry_msgs::Point waypoint = calcRelativeCoordinate(lane.waypoints[i].pose.pose.position, localizer_pose.pose);
+    geometry_msgs::Point waypoint = calcRelativeCoordinate(lane.waypoints[i].pose.pose.position, localizer_pose);
     tf::Vector3 tf_waypoint = point2vector(waypoint);
     tf_waypoint.setZ(0);
 
@@ -326,7 +326,7 @@ int detectDecelerateObstacle(const pcl::PointCloud<pcl::PointXYZ>& points, const
         point_temp.x = p.x;
         point_temp.y = p.y;
         point_temp.z = p.z;
-        obstacle_points->setDeceleratePoint(calcAbsoluteCoordinate(point_temp, localizer_pose.pose));
+        obstacle_points->setDeceleratePoint(calcAbsoluteCoordinate(point_temp, localizer_pose));
       }
     }
 
@@ -660,14 +660,16 @@ int main(int argc, char** argv)
   // velocity set info subscriber
   ros::Subscriber config_sub = rosnode.subscribe("config/velocity_set", 1, &VelocitySetInfo::configCallback, &vs_info);
   ros::Subscriber points_sub = rosnode.subscribe(points_topic, 1, &VelocitySetInfo::pointsCallback, &vs_info);
-  ros::Subscriber localizer_sub =
-      rosnode.subscribe("localizer_pose", 1, &VelocitySetInfo::localizerPoseCallback, &vs_info);
   ros::Subscriber control_pose_sub =
       rosnode.subscribe("current_pose", 1, &VelocitySetInfo::controlPoseCallback, &vs_info);
   ros::Subscriber detectionresult_sub =
       rosnode.subscribe("state/stopline_wpidx", 1, &VelocitySetInfo::detectionCallback, &vs_info);
 
-  // publisher
+  // TF Listener
+  tf2_ros::Buffer tfBuffer;
+  tf2_ros::TransformListener tfListener(tfBuffer);
+
+    // publisher
   ros::Publisher detection_range_pub = rosnode.advertise<visualization_msgs::MarkerArray>("detection_range", 1);
   ros::Publisher obstacle_pub = rosnode.advertise<visualization_msgs::Marker>("obstacle", 1);
   ros::Publisher obstacle_waypoint_pub = rosnode.advertise<std_msgs::Int32>("obstacle_waypoint", 1, true);
@@ -680,6 +682,19 @@ int main(int argc, char** argv)
   while (ros::ok())
   {
     ros::spinOnce();
+
+    geometry_msgs::TransformStamped map_to_lidar_tf;
+
+    try
+    {
+        map_to_lidar_tf = tfBuffer.lookupTransform("map", "lidar", ros::Time::now(), ros::Duration(2.0));
+        vs_info.setLocalizerPose(&map_to_lidar_tf);
+    }
+    catch(tf2::TransformException &ex)
+    {
+        ROS_WARN("%s", ex.what());
+        continue;
+    }
 
     int closest_waypoint = 0;
 

--- a/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
+++ b/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
@@ -683,16 +683,15 @@ int main(int argc, char** argv)
   {
     ros::spinOnce();
 
-    geometry_msgs::TransformStamped map_to_lidar_tf;
-
     try
     {
-        map_to_lidar_tf = tfBuffer.lookupTransform("map", "lidar", ros::Time::now(), ros::Duration(2.0));
-        vs_info.setLocalizerPose(&map_to_lidar_tf);
+        geometry_msgs::TransformStamped map_to_lidar_tf = tfBuffer.lookupTransform(
+          "map", "velodyne", ros::Time::now(), ros::Duration(2.0));
+        vs_info.setLocalizerPose(map_to_lidar_tf);
     }
     catch(tf2::TransformException &ex)
     {
-        ROS_WARN("%s", ex.what());
+        ROS_WARN("Failed to get map->lidar transform. skip computation: %s", ex.what());
         continue;
     }
 


### PR DESCRIPTION
I made velocity_set use the library to lookup the transform instead of using localizer_pose topic.
In VelocitySetInfo I removed the localizerPoseCallback as the TF2 library doesnt use it. Instead created setLocalizerPose.
I also changed the type of localizer_pose_ from geometry_msgs::PoseStamped to geometry_msgs::Pose as it was easy to create and didnt require a lot of changes in the code.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_planning/-/merge_requests/42