### PR TITLE
pure_pursuit: Clean up how control cmds are published

### DIFF
--- a/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
+++ b/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
@@ -35,6 +35,7 @@
 
 #include <vector>
 #include <memory>
+#include <string>
 
 namespace waypoint_follower
 {
@@ -82,8 +83,7 @@ private:
   double update_rate_;
 
   // variables
-  bool is_linear_interpolation_, publishes_for_steering_robot_,
-    add_virtual_end_waypoints_;
+  bool is_linear_interpolation_, add_virtual_end_waypoints_;
   bool is_waypoint_set_, is_pose_set_, is_velocity_set_;
   double current_linear_velocity_, command_linear_velocity_;
   double wheel_base_;
@@ -95,6 +95,7 @@ private:
   double lookahead_distance_ratio_;
   // the next waypoint must be outside of this threshold.
   double minimum_lookahead_distance_;
+  std::string output_interface_;
 
   // callbacks
   void callbackFromConfig(
@@ -108,9 +109,10 @@ private:
   void initForROS();
 
   // functions
+  void publishControlCommands(const bool& can_get_curvature, const double& kappa) const;
   void publishTwistStamped(
     const bool& can_get_curvature, const double& kappa) const;
-  void publishControlCommandStamped(
+  void publishCtrlCmdStamped(
     const bool& can_get_curvature, const double& kappa) const;
   void publishDeviationCurrentPosition(
     const geometry_msgs::Point& point,


### PR DESCRIPTION
- add a new parameter "out_twist_name" to specify output twist topic name (defaults to twist_raw)
- add a new parameter "out_ctrl_cmd_name" to specify ouput ctrl_cmd topic name (default to ctrl_raw)
- add a new parameter "output_interface" to specify which kind of control cmd to be published.
if output_interface == all (default), both type msgs are published.
if output_interface == twist, only TwistStamped type msg is published.
if output_interface == ctrl_cmd, only ControlCommandStamped type msg is published.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_planning/-/merge_requests/29