### PR TITLE
waypoint_planner: Improve stopline stopping

### DIFF
--- a/waypoint_planner/src/velocity_set/velocity_set_path.cpp
+++ b/waypoint_planner/src/velocity_set/velocity_set_path.cpp
@@ -177,10 +177,9 @@ void VelocitySetPath::changeWaypointsForStopping(int stop_waypoint, int obstacle
     updated_waypoints_.waypoints[index].twist.twist.linear.x = sgn * std::min(std::abs(prev_vel), changed_vel);
   }
 
-  // fill velocity with 0 for stopping
-  for (int i = stop_waypoint; i <= obstacle_waypoint; i++)
-  {
-    updated_waypoints_.waypoints[i].twist.twist.linear.x = 0;
+  // fill velocity with 0 for stopping waypoint and the rest.
+  for(auto it = updated_waypoints_.waypoints.begin() + stop_waypoint; it != updated_waypoints_.waypoints.end(); ++it) {
+    it->twist.twist.linear.x = 0.0;
   }
 }
 


### PR DESCRIPTION
- Currently, only waypoints in between STOP_DISTANCE before stop line and stop line are set to zero.
- Ideally, no waypoints after stop line should be published in /final_waypoints in this scenario.
However, decision_make node currently relies on the last waypoint in /final_waypoints to check
whether the final goal has been reached. To avoid changes in decision maker node, we simply set
velocity of waypoints after stop line to zero.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_planning/-/merge_requests/63