### PR TITLE
Remove meaningless enum definition of TrafficLightColors in state machine lib.

### DIFF
--- a/state_machine_lib/include/state_machine_lib/state_flags.hpp
+++ b/state_machine_lib/include/state_machine_lib/state_flags.hpp
@@ -9,14 +9,6 @@ enum class CallbackType
   ENTRY,
   EXIT
 };
-
-enum TrafficLightColors
-{
-  E_RED = 0,
-  E_YELLOW = 0,
-  E_GREEN = 1,
-  E_COLOR_ERROR = 2
-};
 }
 
 #endif


### PR DESCRIPTION
See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_planning/-/merge_requests/68