### PR TITLE
astar_avoid: handle error returned from calling libwaypointfollower::getClosestWaypoint()

### DIFF
--- a/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
+++ b/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
@@ -84,6 +84,7 @@ private:
   bool found_avoid_path_;
   int closest_waypoint_index_;
   int obstacle_waypoint_index_;
+  int closest_local_index_;
   nav_msgs::OccupancyGrid costmap_;
   autoware_msgs::Lane base_waypoints_;
   autoware_msgs::Lane avoid_waypoints_;

--- a/waypoint_planner/src/astar_avoid/astar_avoid.cpp
+++ b/waypoint_planner/src/astar_avoid/astar_avoid.cpp
@@ -21,6 +21,7 @@ AstarAvoid::AstarAvoid()
   , private_nh_("~")
   , closest_waypoint_index_(-1)
   , obstacle_waypoint_index_(-1)
+  , closest_local_index_(-1)
   , costmap_initialized_(false)
   , current_pose_initialized_(false)
   , current_velocity_initialized_(false)
@@ -378,10 +379,9 @@ int AstarAvoid::getLocalClosestWaypoint(const autoware_msgs::Lane& waypoints, co
                                         const int& search_size)
 {
   // search in all waypoints if lane_select judges you're not on waypoints
-  if (closest_waypoint_index_ == -1)
+  if (closest_local_index_ == -1)
   {
-    closest_local_index_ = -1;
-    return getClosestWaypoint(waypoints, pose);
+    closest_local_index_ = getClosestWaypoint(waypoints, pose);
   }
   else
   {
@@ -402,7 +402,7 @@ int AstarAvoid::getLocalClosestWaypoint(const autoware_msgs::Lane& waypoints, co
     {
       closest_local_index_ = -1;
     }
-
-    return closest_local_index;
   }
+
+  return closest_local_index_;
 }

--- a/waypoint_planner/src/astar_avoid/astar_avoid.cpp
+++ b/waypoint_planner/src/astar_avoid/astar_avoid.cpp
@@ -380,7 +380,7 @@ int AstarAvoid::getLocalClosestWaypoint(const autoware_msgs::Lane& waypoints, co
   // search in all waypoints if lane_select judges you're not on waypoints
   if (closest_waypoint_index_ == -1)
   {
-    prev_index = -1;
+    closest_local_index_ = -1;
     return getClosestWaypoint(waypoints, pose);
   }
   else


### PR DESCRIPTION
Must be merged before #36 

For detailed explanation, see https://gitlab.com/astuff/autoware.ai/core_planning/-/issues/39

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_planning/-/merge_requests/71